### PR TITLE
Change shebang to python2 instead of just python

### DIFF
--- a/dymerge.py
+++ b/dymerge.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # dymerge.py
 
 """


### PR DESCRIPTION
The latest versions of Ubuntu, as well as a few other distros that have replaced python2 with python3, and made python3 the default python executable, will work better with this change